### PR TITLE
feature/etl supplier performance

### DIFF
--- a/ETL_Airflow/dags/metamorph_etl_dag.py
+++ b/ETL_Airflow/dags/metamorph_etl_dag.py
@@ -10,14 +10,15 @@ from tasks.m_supplier_performance_task import m_load_supplier_performance
     catchup=False,
 )
 def etl_process():
-    supplier_task = m_ingest_data_into_suppliers()
-    product_task = m_ingest_data_into_products()
-    customer_task = m_ingest_data_into_customers()
-    sales_task = m_ingest_data_into_sales()
+    # supplier_task = m_ingest_data_into_suppliers()
+    # product_task = m_ingest_data_into_products()
+    # customer_task = m_ingest_data_into_customers()
+    # sales_task = m_ingest_data_into_sales()
     supplier_performance_task = m_load_supplier_performance()
 
     # Set dependencies inside the DAG function
-    [ supplier_task , product_task , customer_task , sales_task ]  >> supplier_performance_task
+   
+    supplier_performance_task
   
 
 dag_instance = etl_process()

--- a/ETL_Airflow/dags/metamorph_etl_dag.py
+++ b/ETL_Airflow/dags/metamorph_etl_dag.py
@@ -1,7 +1,7 @@
 from airflow.decorators import dag
 from datetime import datetime
-from tasks.ingestion_task import m_ingest_data_into_suppliers,m_ingest_data_into_products,m_ingest_data_into_customers,m_ingest_data_into_sales,m_load_supplier_performance
-
+from tasks.ingestion_task import m_ingest_data_into_suppliers,m_ingest_data_into_products,m_ingest_data_into_customers,m_ingest_data_into_sales
+from tasks.m_supplier_performance_task import m_load_supplier_performance
 
 @dag(
     dag_id="ingestion_data_pipeline",
@@ -14,7 +14,7 @@ def etl_process():
     product_task = m_ingest_data_into_products()
     customer_task = m_ingest_data_into_customers()
     sales_task = m_ingest_data_into_sales()
-    supplier_performance_task =m_load_supplier_performance()
+    supplier_performance_task = m_load_supplier_performance()
 
     # Set dependencies inside the DAG function
     [ supplier_task , product_task , customer_task , sales_task ]  >> supplier_performance_task

--- a/ETL_Airflow/dags/metamorph_etl_dag.py
+++ b/ETL_Airflow/dags/metamorph_etl_dag.py
@@ -10,15 +10,14 @@ from tasks.m_supplier_performance_task import m_load_supplier_performance
     catchup=False,
 )
 def etl_process():
-    # supplier_task = m_ingest_data_into_suppliers()
-    # product_task = m_ingest_data_into_products()
-    # customer_task = m_ingest_data_into_customers()
-    # sales_task = m_ingest_data_into_sales()
+    supplier_task = m_ingest_data_into_suppliers()
+    product_task = m_ingest_data_into_products()
+    customer_task = m_ingest_data_into_customers()
+    sales_task = m_ingest_data_into_sales()
     supplier_performance_task = m_load_supplier_performance()
 
     # Set dependencies inside the DAG function
-   
-    supplier_performance_task
+    [ supplier_task , product_task , customer_task , sales_task ]  >> supplier_performance_task
   
 
 dag_instance = etl_process()

--- a/ETL_Airflow/dags/metamorph_etl_dag.py
+++ b/ETL_Airflow/dags/metamorph_etl_dag.py
@@ -1,6 +1,7 @@
 from airflow.decorators import dag
 from datetime import datetime
-from tasks.ingestion_task import m_ingest_data_into_suppliers, m_ingest_data_into_products, m_ingest_data_into_customers,m_ingest_data_into_sales
+from tasks.ingestion_task import m_ingest_data_into_suppliers,m_ingest_data_into_products,m_ingest_data_into_customers,m_ingest_data_into_sales,m_load_supplier_performance
+
 
 @dag(
     dag_id="ingestion_data_pipeline",
@@ -13,9 +14,10 @@ def etl_process():
     product_task = m_ingest_data_into_products()
     customer_task = m_ingest_data_into_customers()
     sales_task = m_ingest_data_into_sales()
+    supplier_performance_task =m_load_supplier_performance()
 
     # Set dependencies inside the DAG function
-    supplier_task >> product_task >> customer_task >> sales_task
+    [ supplier_task , product_task , customer_task , sales_task ]  >> supplier_performance_task
   
 
 dag_instance = etl_process()

--- a/ETL_Airflow/dags/metamorph_etl_dag.py
+++ b/ETL_Airflow/dags/metamorph_etl_dag.py
@@ -1,6 +1,6 @@
 from airflow.decorators import dag
 from datetime import datetime
-from tasks.ingestion_task import m_ingest_data_into_suppliers,m_ingest_data_into_products,m_ingest_data_into_customers,m_ingest_data_into_sales
+from tasks.ingestion_task import m_ingest_data_into_suppliers, m_ingest_data_into_products, m_ingest_data_into_customers, m_ingest_data_into_sales
 from tasks.m_supplier_performance_task import m_load_supplier_performance
 
 @dag(
@@ -17,7 +17,7 @@ def etl_process():
     supplier_performance_task = m_load_supplier_performance()
 
     # Set dependencies inside the DAG function
-    [ supplier_task , product_task , customer_task , sales_task ]  >> supplier_performance_task
+    [supplier_task, product_task, customer_task, sales_task]  >> supplier_performance_task
   
 
 dag_instance = etl_process()

--- a/ETL_Airflow/dags/tasks/ingestion_task.py
+++ b/ETL_Airflow/dags/tasks/ingestion_task.py
@@ -1,6 +1,6 @@
 from airflow.decorators import task
 from airflow.exceptions import AirflowException
-from utils import init_spark, APIClient, load_to_postgres, DuplicateValidator,read_from_postgres
+from utils import init_spark, APIClient, load_to_postgres, DuplicateValidator
 import logging
 from pyspark.sql.functions import col
 

--- a/ETL_Airflow/dags/tasks/ingestion_task.py
+++ b/ETL_Airflow/dags/tasks/ingestion_task.py
@@ -51,7 +51,7 @@ def m_ingest_data_into_suppliers():
 
 
         # Load the cleaned data to PostgreSQL        
-        load_to_postgres(suppliers_df_tgt, "raw.suppliers","overwrite")
+        load_to_postgres(suppliers_df_tgt, "raw.suppliers", "overwrite")
         
        
         return "Suppliers ETL process completed successfully."
@@ -114,7 +114,7 @@ def m_ingest_data_into_products():
         validator.validate_no_duplicates(df, key_columns=["PRODUCT_ID"])
 
         # Load data       
-        load_to_postgres(products_df_tgt, "raw.products","overwrite")
+        load_to_postgres(products_df_tgt, "raw.products", "overwrite")
 
         
         return "Products ETL process completed successfully."
@@ -169,7 +169,7 @@ def m_ingest_data_into_customers():
         validator = DuplicateValidator()
         validator.validate_no_duplicates(df, key_columns=["CUSTOMER_ID"])
         # Load data
-        load_to_postgres(customers_df_tgt, "raw.customers","overwrite")
+        load_to_postgres(customers_df_tgt, "raw.customers", "overwrite")
 
         
         return "Customers ETL process completed successfully."
@@ -238,7 +238,7 @@ def m_ingest_data_into_sales():
         validator.validate_no_duplicates(sales_df_tgt, key_columns=["SALE_ID"])
 
         # Load the cleaned data to PostgreSQL
-        load_to_postgres(sales_df_tgt, "raw.sales","overwrite")
+        load_to_postgres(sales_df_tgt, "raw.sales", "overwrite")
         
         
         return "Sales ETL process completed successfully."

--- a/ETL_Airflow/dags/tasks/ingestion_task.py
+++ b/ETL_Airflow/dags/tasks/ingestion_task.py
@@ -2,8 +2,8 @@ from airflow.decorators import task
 from airflow.exceptions import AirflowException
 from utils import init_spark, APIClient, load_to_postgres, DuplicateValidator,read_from_postgres
 import logging
-from pyspark.sql.functions import col, sum as _sum, countDistinct, current_date, row_number,when
-from pyspark.sql.window import Window
+from pyspark.sql.functions import col
+
 
 
 log = logging.getLogger(__name__)
@@ -250,92 +250,3 @@ def m_ingest_data_into_sales():
     finally:
             spark.stop()
 
-
-
-@task
-def m_load_supplier_performance():
-    try:
-        spark = init_spark()
-
-        
-        SQ_Shortcut_To_sales = read_from_postgres(spark, "raw.sales")        
-        SQ_Shortcut_To_products = read_from_postgres(spark, "raw.products")
-        SQ_Shortcut_To_suppliers = read_from_postgres(spark, "raw.suppliers")
-       
-        sales_filtered = SQ_Shortcut_To_sales.filter(col("ORDER_STATUS") != "CANCELLED")
-
-        
-        JNR_Sales_Products = sales_filtered.join(
-            SQ_Shortcut_To_products, on="PRODUCT_ID", how="inner"
-        )
-        JNR_Products_Suppliers = JNR_Sales_Products.join(
-            SQ_Shortcut_To_suppliers, on="SUPPLIER_ID", how="inner"
-        )
-
-       
-        JNR_Products_Suppliers = JNR_Products_Suppliers.withColumn(
-            "REVENUE", col("QUANTITY") * col("SELLING_PRICE")
-        )
-
-        
-        AGG_TRANS_Product_Level = JNR_Products_Suppliers.groupBy(
-            "SUPPLIER_ID", "PRODUCT_ID", "PRODUCT_NAME"
-        ).agg(
-            _sum("REVENUE").alias("agg_product_revenue"),
-            _sum("QUANTITY").alias("agg_stock_sold")
-        )
-
-       
-        AGG_TRANS_Supplier_Level = AGG_TRANS_Product_Level.groupBy("SUPPLIER_ID").agg(
-            _sum("agg_product_revenue").alias("agg_total_revenue"),
-            countDistinct("PRODUCT_ID").alias("agg_total_products_sold"),
-            _sum("agg_stock_sold").alias("agg_total_stock_sold")
-        )
-
-       
-        windowSpec = Window.partitionBy("SUPPLIER_ID").orderBy(col("agg_product_revenue").desc())
-        ranked_df = AGG_TRANS_Product_Level.withColumn("RANK", row_number().over(windowSpec))
-
-        top_selling_product_df = ranked_df.filter(col("RANK") == 1).select(
-            "SUPPLIER_ID", col("PRODUCT_NAME").alias("TOP_SELLING_PRODUCT")
-        )
-
-        final_result = SQ_Shortcut_To_suppliers.join(
-            AGG_TRANS_Supplier_Level, on="SUPPLIER_ID", how="left"
-        ).join(
-            top_selling_product_df, on="SUPPLIER_ID", how="left"
-        ).fillna(0, subset=[
-            "agg_total_revenue", "agg_total_products_sold", "agg_total_stock_sold"
-        ]).withColumn(
-            "TOP_SELLING_PRODUCT",
-            when(
-                col("TOP_SELLING_PRODUCT").isNull() | (col("TOP_SELLING_PRODUCT") == ""),
-                "No Sales"
-            ).otherwise(col("TOP_SELLING_PRODUCT"))
-        ).withColumn("DAY_DT", current_date())
-
-        Shortcut_To_supplier_performance_tgt = final_result.select(
-                                                col("DAY_DT"),
-                                                col("SUPPLIER_ID"),
-                                                col("SUPPLIER_NAME"),
-                                                col("agg_total_revenue").alias("TOTAL_REVENUE"),
-                                                col("agg_total_products_sold").alias("TOTAL_PRODUCTS_SOLD"),
-                                                col("agg_total_stock_sold").alias("TOTAL_STOCK_SOLD"),
-                                                col("TOP_SELLING_PRODUCT")
-                                              )
-
-        
-        validator = DuplicateValidator()
-        validator.validate_no_duplicates(Shortcut_To_supplier_performance_tgt,key_columns=["SUPPLIER_ID", "DAY_DT"] )
-
-      
-        load_to_postgres(Shortcut_To_supplier_performance_tgt,"legacy.supplier_performance","append")   
-
-        return "Supplier Performance task finished."
-
-    except Exception as e:
-        log.error(f"ETL task failed: {str(e)}", exc_info=True)
-        raise
-
-    finally:
-        spark.stop()

--- a/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
@@ -1,8 +1,8 @@
 from airflow.decorators import task
 from airflow.exceptions import AirflowException
-from utils import init_spark,load_to_postgres,DuplicateValidator,read_from_postgres
+from utils import init_spark,load_to_postgres,DuplicateValidator, read_from_postgres
 import logging
-from pyspark.sql.functions import col, sum as _sum  , countDistinct, current_date, row_number,when
+from pyspark.sql.functions import col, sum , countDistinct, current_date, row_number,when
 from pyspark.sql.window import Window
 
 log = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ def m_load_supplier_performance():
         # Processing Node : SQ_Shortcut_To_sales - Reads data from 'raw.sales' table
         SQ_Shortcut_To_sales = read_from_postgres(spark, "raw.sales")
         SQ_Shortcut_To_sales = SQ_Shortcut_To_sales\
-                                 .select(
+                                .select(
                                     col("ORDER_STATUS"),
                                     col("PRODUCT_ID"),
                                     col("QUANTITY"),
@@ -27,11 +27,11 @@ def m_load_supplier_performance():
         # Processing Node : SQ_Shortcut_To_Products - Reads data from 'raw.products' table
         SQ_Shortcut_To_Products = read_from_postgres(spark, "raw.products")
         SQ_Shortcut_To_Products = SQ_Shortcut_To_Products \
-                                     .select(                                      
-                                      col("PRODUCT_ID"),
-                                      col("SUPPLIER_ID"),
-                                      col("PRODUCT_NAME"),
-                                      col("SELLING_PRICE")                                   
+                                    .select(                                      
+                                        col("PRODUCT_ID"),
+                                        col("SUPPLIER_ID"),
+                                        col("PRODUCT_NAME"),
+                                        col("SELLING_PRICE")                                   
                                     )
         log.info(f"Data Frame : 'SQ_Shortcut_To_products' is built....")
 
@@ -45,7 +45,10 @@ def m_load_supplier_performance():
         log.info(f"Data Frame : 'SQ_Shortcut_To_suppliers' is built....")
         
         # Processing Node : FIL_Cancelled_Sales - Filters out cancelled orders
-        FIL_Cancelled_Sales = SQ_Shortcut_To_sales.filter(SQ_Shortcut_To_sales.ORDER_STATUS != "CANCELLED")
+        FIL_Cancelled_Sales = SQ_Shortcut_To_sales\
+                                .filter(
+                                    SQ_Shortcut_To_sales.ORDER_STATUS != "CANCELLED"
+                                )
         log.info(f"Data Frame : 'FIL_Cancelled_Sales' is built....")
         
         # Processing Node : JNR_Sales_Products - Joins sales data with product data on PRODUCT_ID
@@ -87,65 +90,107 @@ def m_load_supplier_performance():
         log.info(f"Data Frame : 'JNR_Products_Suppliers' is built....")                             
                                    
         # Processing Node : AGG_TRANS_Product_Level - Aggregates data at the product level per supplier
-        AGG_TRANS_Product_Level = JNR_Products_Suppliers.groupBy(
-            "SUPPLIER_ID", "PRODUCT_ID", "PRODUCT_NAME"
-        ).agg(
-            _sum("REVENUE").alias("agg_product_revenue"),
-            _sum("QUANTITY").alias("agg_stock_sold")
-        )
+        AGG_TRANS_Product_Level = JNR_Products_Suppliers\
+                                    .groupBy(
+                                        ["SUPPLIER_ID", "PRODUCT_ID", "PRODUCT_NAME"]
+                                    )\
+                                    .agg(
+                                        sum("REVENUE").alias("agg_product_revenue"),
+                                        sum("QUANTITY").alias("agg_stock_sold")
+                                    )
         log.info(f"Data Frame : 'AGG_TRANS_Product_Level' is built....")
        
         # Processing Node : AGG_TRANS_Supplier_Level - Aggregates data at the supplier level
-        AGG_TRANS_Supplier_Level = AGG_TRANS_Product_Level.groupBy("SUPPLIER_ID").agg(
-            _sum("agg_product_revenue").alias("agg_total_revenue"),
-            countDistinct("PRODUCT_ID").alias("agg_total_products_sold"),
-            _sum("agg_stock_sold").alias("agg_total_stock_sold")
-        )
+        AGG_TRANS_Supplier_Level = AGG_TRANS_Product_Level\
+                                    .groupBy(
+                                        "SUPPLIER_ID"
+                                    )\
+                                    .agg(
+                                        sum("agg_product_revenue").alias("agg_total_revenue"),
+                                        countDistinct("PRODUCT_ID").alias("agg_total_products_sold"),
+                                        sum("agg_stock_sold").alias("agg_total_stock_sold")
+                                    )
         log.info(f"Data Frame : 'AGG_TRANS_Supplier_Level' is built....")
        
         # Processing Node : RNK_Suppliers_df - Ranks products per supplier based on revenue
         windowSpec = Window.partitionBy("SUPPLIER_ID").orderBy(col("agg_product_revenue").desc())
         RNK_Suppliers_df = AGG_TRANS_Product_Level.withColumn("RANK", row_number().over(windowSpec))
+        log.info(f"Data Frame : 'RNK_Suppliers_df' is built....")
 
         # Processing Node : Top_Selling_Product_df - Filters to get the top selling product per supplier
-        Top_Selling_Product_df = RNK_Suppliers_df.filter(col("RANK") == 1).select(
-            "SUPPLIER_ID", col("PRODUCT_NAME").alias("TOP_SELLING_PRODUCT")
-        )
+        Top_Selling_Product_df = RNK_Suppliers_df\
+                                    .filter(col("RANK") == 1)\
+                                    .select(
+                                        col("SUPPLIER_ID"),
+                                        col("PRODUCT_NAME").alias("TOP_SELLING_PRODUCT")
+                                    )
         log.info(f"Data Frame : 'Top_Selling_Product_df' is built....")
 
-        # Processing Node : JNR_Supplier_Aggregates_And_Top_Product - Combines all supplier metrics and top product
-        JNR_Supplier_Aggregates_And_Top_Product = SQ_Shortcut_To_Suppliers.join(
-            AGG_TRANS_Supplier_Level, on="SUPPLIER_ID", how="left"
-        ).join(
-            Top_Selling_Product_df, on="SUPPLIER_ID", how="left"
-        ).fillna(0, subset=[
-            "agg_total_revenue", "agg_total_products_sold", "agg_total_stock_sold"
-        ]).withColumn(
-            "TOP_SELLING_PRODUCT",
-            when(
-                col("TOP_SELLING_PRODUCT").isNull() | (col("TOP_SELLING_PRODUCT") == ""),
-                "No Sales"
-            ).otherwise(col("TOP_SELLING_PRODUCT"))
-        ).withColumn("DAY_DT", current_date())
-        log.info(f"Data Frame : 'JNR_Supplier_Aggregates_And_Top_Product' is built....")
+        # Processing Node : JNR_Supplier_Agg_Level - Combines all supplier metrics 
+        JNR_Supplier_Agg_Level = SQ_Shortcut_To_Suppliers\
+                                    .join(
+                                        AGG_TRANS_Supplier_Level,
+                                        on="SUPPLIER_ID",
+                                        how="left"         
+                                    )\
+                                    .select(
+                                        SQ_Shortcut_To_Suppliers.SUPPLIER_ID,
+                                        SQ_Shortcut_To_Suppliers.SUPPLIER_NAME,
+                                        AGG_TRANS_Supplier_Level.agg_total_revenue,
+                                        AGG_TRANS_Supplier_Level.agg_total_products_sold,
+                                        AGG_TRANS_Supplier_Level.agg_total_stock_sold
+                                    )
+        log.info(f"Data Frame : 'JNR_Supplier_Agg_Level' is built....")
+
+        # Processing Node : JNR_Supplier_Agg_Top_Selling_Product - Combines all supplier_Agg_level metrics and top product
+        JNR_Supplier_Agg_Top_Selling_Product = JNR_Supplier_Agg_Level\
+                                                    .join(
+                                                        Top_Selling_Product_df,
+                                                        on="SUPPLIER_ID", 
+                                                        how="left"
+                                                    )\
+                                                    .select(
+                                                        JNR_Supplier_Agg_Level.SUPPLIER_ID,
+                                                        JNR_Supplier_Agg_Level.SUPPLIER_NAME,
+                                                        JNR_Supplier_Agg_Level.agg_total_revenue,
+                                                        JNR_Supplier_Agg_Level.agg_total_products_sold,
+                                                        JNR_Supplier_Agg_Level.agg_total_stock_sold,
+                                                        Top_Selling_Product_df.TOP_SELLING_PRODUCT
+                                                    )\
+                                                    .fillna(
+                                                        0, subset=["agg_total_revenue", "agg_total_products_sold", "agg_total_stock_sold"]
+                                                    )\
+                                                    .withColumn(
+                                                        "TOP_SELLING_PRODUCT",
+                                                        when(
+                                                            col("TOP_SELLING_PRODUCT").isNull() | (col("TOP_SELLING_PRODUCT") == ""),
+                                                            "No Sales"
+                                                        )\
+                                                        .otherwise(
+                                                            col("TOP_SELLING_PRODUCT")
+                                                        )
+                                                    )\
+                                                    .withColumn("DAY_DT", current_date())              
+        log.info(f"Data Frame : 'JNR_Supplier_Agg_Top_Selling_Product' is built....")
 
         # Processing Node : Shortcut_To_Supplier_Performance_Tgt - Final selection for loading to target
-        Shortcut_To_Supplier_Performance_Tgt = JNR_Supplier_Aggregates_And_Top_Product.select(
-                                                col("DAY_DT"),
-                                                col("SUPPLIER_ID"),
-                                                col("SUPPLIER_NAME"),
-                                                col("agg_total_revenue").alias("TOTAL_REVENUE"),
-                                                col("agg_total_products_sold").alias("TOTAL_PRODUCTS_SOLD"),
-                                                col("agg_total_stock_sold").alias("TOTAL_STOCK_SOLD"),
-                                                col("TOP_SELLING_PRODUCT")
-                                              )
+        Shortcut_To_Supplier_Performance_Tgt = JNR_Supplier_Agg_Top_Selling_Product\
+                                                    .select(
+                                                        col("DAY_DT"),
+                                                        col("SUPPLIER_ID"),
+                                                        col("SUPPLIER_NAME"),
+                                                        col("agg_total_revenue").alias("TOTAL_REVENUE"),
+                                                        col("agg_total_products_sold").alias("TOTAL_PRODUCTS_SOLD"),
+                                                        col("agg_total_stock_sold").alias("TOTAL_STOCK_SOLD"),
+                                                        col("TOP_SELLING_PRODUCT")
+                                                    )
         log.info(f"Data Frame : 'Shortcut_To_Supplier_Performance_Tgt' is built....")
 
         validator = DuplicateValidator()
         validator.validate_no_duplicates(Shortcut_To_Supplier_Performance_Tgt,key_columns=["SUPPLIER_ID", "DAY_DT"] )
 
       
-        load_to_postgres(Shortcut_To_Supplier_Performance_Tgt,"legacy.supplier_performance","append")   
+        load_to_postgres(Shortcut_To_Supplier_Performance_Tgt, "legacy.supplier_performance", "append")   
 
         return "Supplier Performance task finished."
 

--- a/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
@@ -19,7 +19,8 @@ def m_load_supplier_performance():
                                  .select(
                                     col("ORDER_STATUS"),
                                     col("PRODUCT_ID"),
-                                    col("QUANTITY")                                  
+                                    col("QUANTITY"),
+                                    col("DISCOUNT")                                 
                                 )        
         log.info(f"Data Frame : 'SQ_Shortcut_To_sales' is built....")
 
@@ -56,6 +57,7 @@ def m_load_supplier_performance():
                                 )\
                                 .select(
                                     SQ_Shortcut_To_sales.QUANTITY,
+                                    SQ_Shortcut_To_sales.DISCOUNT,
                                     SQ_Shortcut_To_Products.PRODUCT_ID, 
                                     SQ_Shortcut_To_Products.SUPPLIER_ID,
                                     SQ_Shortcut_To_Products.PRODUCT_NAME,
@@ -75,11 +77,12 @@ def m_load_supplier_performance():
                                         JNR_Sales_Products.PRODUCT_NAME,
                                         JNR_Sales_Products.QUANTITY,
                                         JNR_Sales_Products.SELLING_PRICE,
+                                        JNR_Sales_Products.DISCOUNT,
                                         SQ_Shortcut_To_Suppliers.SUPPLIER_ID,
                                         SQ_Shortcut_To_Suppliers.SUPPLIER_NAME  
                                      )\
                                     .withColumn(
-                                        "REVENUE", col("QUANTITY") * col("SELLING_PRICE")
+                                        "REVENUE",  (col("SELLING_PRICE") - (col("SELLING_PRICE") * col("DISCOUNT") / 100)) * col("QUANTITY")
                                     )        
         log.info(f"Data Frame : 'JNR_Products_Suppliers' is built....")                             
                                    
@@ -137,7 +140,7 @@ def m_load_supplier_performance():
                                                 col("TOP_SELLING_PRODUCT")
                                               )
         log.info(f"Data Frame : 'Shortcut_To_Supplier_Performance_Tgt' is built....")
-        
+
         validator = DuplicateValidator()
         validator.validate_no_duplicates(Shortcut_To_Supplier_Performance_Tgt,key_columns=["SUPPLIER_ID", "DAY_DT"] )
 

--- a/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
@@ -2,7 +2,7 @@ from airflow.decorators import task
 from airflow.exceptions import AirflowException
 from utils import init_spark,load_to_postgres,DuplicateValidator,read_from_postgres
 import logging
-from pyspark.sql.functions import col, sum , countDistinct, current_date, row_number,when
+from pyspark.sql.functions import col, sum as _sum  , countDistinct, current_date, row_number,when
 from pyspark.sql.window import Window
 
 log = logging.getLogger(__name__)
@@ -19,22 +19,22 @@ def m_load_supplier_performance():
                                  .select(
                                     col("ORDER_STATUS"),
                                     col("PRODUCT_ID"),
-                                    col("QUANTITY"),
-                                    col("SELLING_PRICE")
+                                    col("QUANTITY")                                  
                                 )        
         log.info(f"Data Frame : 'SQ_Shortcut_To_sales' is built....")
 
-        SQ_Shortcut_To_products = read_from_postgres(spark, "raw.products")
-        SQ_Shortcut_To_products = SQ_Shortcut_To_products \
+        SQ_Shortcut_To_Products = read_from_postgres(spark, "raw.products")
+        SQ_Shortcut_To_Products = SQ_Shortcut_To_Products \
                                      .select(                                      
                                       col("PRODUCT_ID"),
                                       col("SUPPLIER_ID"),
-                                      col("PRODUCT_NAME")                                    
+                                      col("PRODUCT_NAME"),
+                                      col("SELLING_PRICE")                                   
                                     )
         log.info(f"Data Frame : 'SQ_Shortcut_To_products' is built....")
 
-        SQ_Shortcut_To_suppliers = read_from_postgres(spark, "raw.suppliers")
-        SQ_Shortcut_To_suppliers =  SQ_Shortcut_To_suppliers\
+        SQ_Shortcut_To_Suppliers = read_from_postgres(spark, "raw.suppliers")
+        SQ_Shortcut_To_Suppliers =  SQ_Shortcut_To_Suppliers\
                                     .select(
                                         col("SUPPLIER_ID"),
                                         col("SUPPLIER_NAME")
@@ -44,13 +44,23 @@ def m_load_supplier_performance():
         FIL_Cancelled_Sales = SQ_Shortcut_To_sales.filter(col("ORDER_STATUS") != "CANCELLED")
 
         
-        JNR_Sales_Products = FIL_Cancelled_Sales.join(
-            SQ_Shortcut_To_products, on="PRODUCT_ID", how="inner"
+        JNR_Sales_Products = FIL_Cancelled_Sales.select(
+            "PRODUCT_ID", "QUANTITY"
+        ).join(
+        SQ_Shortcut_To_Products.select("PRODUCT_ID", "SUPPLIER_ID", "PRODUCT_NAME"),
+            on="PRODUCT_ID",
+            how="inner"
         )
-        JNR_Products_Suppliers = JNR_Sales_Products.join(
-            SQ_Shortcut_To_suppliers, on="SUPPLIER_ID", how="inner"
+
+        # Join with suppliers with selected columns
+        JNR_Products_Suppliers = JNR_Sales_Products.select(
+            "PRODUCT_ID", "PRODUCT_NAME", "SUPPLIER_ID", "QUANTITY"
+        ).join(
+            SQ_Shortcut_To_Suppliers.select("SUPPLIER_ID", "SUPPLIER_NAME"),
+            on="SUPPLIER_ID",
+            how="inner"
         )
-      
+
        
         JNR_Products_Suppliers = JNR_Products_Suppliers.withColumn(
             "REVENUE", col("QUANTITY") * col("SELLING_PRICE")
@@ -60,29 +70,29 @@ def m_load_supplier_performance():
         AGG_TRANS_Product_Level = JNR_Products_Suppliers.groupBy(
             "SUPPLIER_ID", "PRODUCT_ID", "PRODUCT_NAME"
         ).agg(
-            sum("REVENUE").alias("agg_product_revenue"),
-            sum("QUANTITY").alias("agg_stock_sold")
+            _sum("REVENUE").alias("agg_product_revenue"),
+            _sum("QUANTITY").alias("agg_stock_sold")
         )
         
        
         AGG_TRANS_Supplier_Level = AGG_TRANS_Product_Level.groupBy("SUPPLIER_ID").agg(
-            sum("agg_product_revenue").alias("agg_total_revenue"),
+            _sum("agg_product_revenue").alias("agg_total_revenue"),
             countDistinct("PRODUCT_ID").alias("agg_total_products_sold"),
-            sum("agg_stock_sold").alias("agg_total_stock_sold")
+            _sum("agg_stock_sold").alias("agg_total_stock_sold")
         )
 
        
         windowSpec = Window.partitionBy("SUPPLIER_ID").orderBy(col("agg_product_revenue").desc())
-        ranked_df = AGG_TRANS_Product_Level.withColumn("RANK", row_number().over(windowSpec))
+        RNK_Suppliers_df = AGG_TRANS_Product_Level.withColumn("RANK", row_number().over(windowSpec))
 
-        top_selling_product_df = ranked_df.filter(col("RANK") == 1).select(
+        Top_Selling_Product_df = RNK_Suppliers_df.filter(col("RANK") == 1).select(
             "SUPPLIER_ID", col("PRODUCT_NAME").alias("TOP_SELLING_PRODUCT")
         )
 
-        final_result = SQ_Shortcut_To_suppliers.join(
+        JNR_Supplier_Aggregates_And_Top_Product = SQ_Shortcut_To_Suppliers.join(
             AGG_TRANS_Supplier_Level, on="SUPPLIER_ID", how="left"
         ).join(
-            top_selling_product_df, on="SUPPLIER_ID", how="left"
+            Top_Selling_Product_df, on="SUPPLIER_ID", how="left"
         ).fillna(0, subset=[
             "agg_total_revenue", "agg_total_products_sold", "agg_total_stock_sold"
         ]).withColumn(
@@ -93,7 +103,7 @@ def m_load_supplier_performance():
             ).otherwise(col("TOP_SELLING_PRODUCT"))
         ).withColumn("DAY_DT", current_date())
 
-        Shortcut_To_supplier_performance_tgt = final_result.select(
+        Shortcut_To_Supplier_Performance_Tgt = JNR_Supplier_Aggregates_And_Top_Product.select(
                                                 col("DAY_DT"),
                                                 col("SUPPLIER_ID"),
                                                 col("SUPPLIER_NAME"),
@@ -105,10 +115,10 @@ def m_load_supplier_performance():
 
         
         validator = DuplicateValidator()
-        validator.validate_no_duplicates(Shortcut_To_supplier_performance_tgt,key_columns=["SUPPLIER_ID", "DAY_DT"] )
+        validator.validate_no_duplicates(Shortcut_To_Supplier_Performance_Tgt,key_columns=["SUPPLIER_ID", "DAY_DT"] )
 
       
-        load_to_postgres(Shortcut_To_supplier_performance_tgt,"legacy.supplier_performance","append")   
+        load_to_postgres(Shortcut_To_Supplier_Performance_Tgt,"legacy.supplier_performance","append")   
 
         return "Supplier Performance task finished."
 

--- a/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
@@ -13,7 +13,7 @@ def m_load_supplier_performance():
     try:
         spark = init_spark()
 
-        #processing node SQ_Shortcut_To_sales -reads data from sales table
+        # Processing Node : SQ_Shortcut_To_sales -reads data from sales table
         SQ_Shortcut_To_sales = read_from_postgres(spark, "raw.sales")
         SQ_Shortcut_To_sales = SQ_Shortcut_To_sales\
                                  .select(
@@ -40,47 +40,62 @@ def m_load_supplier_performance():
                                         col("SUPPLIER_NAME")
                                     )
         log.info(f"Data Frame : 'SQ_Shortcut_To_suppliers' is built....")
-       
-        FIL_Cancelled_Sales = SQ_Shortcut_To_sales.filter(col("ORDER_STATUS") != "CANCELLED")
-
         
-        JNR_Sales_Products = FIL_Cancelled_Sales.select(
-            "PRODUCT_ID", "QUANTITY"
-        ).join(
-        SQ_Shortcut_To_Products.select("PRODUCT_ID", "SUPPLIER_ID", "PRODUCT_NAME"),
-            on="PRODUCT_ID",
-            how="inner"
-        )
-
+       
+        FIL_Cancelled_Sales = SQ_Shortcut_To_sales.filter(SQ_Shortcut_To_sales.ORDER_STATUS != "CANCELLED")
+        log.info(f"Data Frame : 'FIL_Cancelled_Sales' is built....")
+        
+        
+        JNR_Sales_Products = FIL_Cancelled_Sales\
+                                .join( 
+                                    SQ_Shortcut_To_Products, 
+                                    on="PRODUCT_ID",
+                                    how="inner"
+                                )\
+                                .select(
+                                    SQ_Shortcut_To_sales.QUANTITY,
+                                    SQ_Shortcut_To_Products.PRODUCT_ID, 
+                                    SQ_Shortcut_To_Products.SUPPLIER_ID,
+                                    SQ_Shortcut_To_Products.PRODUCT_NAME,
+                                    SQ_Shortcut_To_Products.SELLING_PRICE
+                                )       
+        log.info(f"Data Frame : 'JNR_Sales_Products' is built....")
+        
         # Join with suppliers with selected columns
-        JNR_Products_Suppliers = JNR_Sales_Products.select(
-            "PRODUCT_ID", "PRODUCT_NAME", "SUPPLIER_ID", "QUANTITY"
-        ).join(
-            SQ_Shortcut_To_Suppliers.select("SUPPLIER_ID", "SUPPLIER_NAME"),
-            on="SUPPLIER_ID",
-            how="inner"
-        )
-
-       
-        JNR_Products_Suppliers = JNR_Products_Suppliers.withColumn(
-            "REVENUE", col("QUANTITY") * col("SELLING_PRICE")
-        )
-
-        
+        JNR_Products_Suppliers = JNR_Sales_Products\
+                                    .join(
+                                        SQ_Shortcut_To_Suppliers,
+                                        on="SUPPLIER_ID",
+                                        how="inner"
+                                    )\
+                                    .select(
+                                        JNR_Sales_Products.PRODUCT_ID,
+                                        JNR_Sales_Products.PRODUCT_NAME,
+                                        JNR_Sales_Products.QUANTITY,
+                                        JNR_Sales_Products.SELLING_PRICE,
+                                        SQ_Shortcut_To_Suppliers.SUPPLIER_ID,
+                                        SQ_Shortcut_To_Suppliers.SUPPLIER_NAME  
+                                     ).withColumn(
+                                        "REVENUE", col("QUANTITY") * col("SELLING_PRICE")
+                                    )        
+        log.info(f"Data Frame : 'JNR_Products_Suppliers' is built....")                             
+                                   
+                               
+                                           
         AGG_TRANS_Product_Level = JNR_Products_Suppliers.groupBy(
             "SUPPLIER_ID", "PRODUCT_ID", "PRODUCT_NAME"
         ).agg(
             _sum("REVENUE").alias("agg_product_revenue"),
             _sum("QUANTITY").alias("agg_stock_sold")
         )
-        
+        log.info(f"Data Frame : 'AGG_TRANS_Product_Level' is built....")
        
         AGG_TRANS_Supplier_Level = AGG_TRANS_Product_Level.groupBy("SUPPLIER_ID").agg(
             _sum("agg_product_revenue").alias("agg_total_revenue"),
             countDistinct("PRODUCT_ID").alias("agg_total_products_sold"),
             _sum("agg_stock_sold").alias("agg_total_stock_sold")
         )
-
+        log.info(f"Data Frame : 'AGG_TRANS_Supplier_Level' is built....")
        
         windowSpec = Window.partitionBy("SUPPLIER_ID").orderBy(col("agg_product_revenue").desc())
         RNK_Suppliers_df = AGG_TRANS_Product_Level.withColumn("RANK", row_number().over(windowSpec))
@@ -88,6 +103,7 @@ def m_load_supplier_performance():
         Top_Selling_Product_df = RNK_Suppliers_df.filter(col("RANK") == 1).select(
             "SUPPLIER_ID", col("PRODUCT_NAME").alias("TOP_SELLING_PRODUCT")
         )
+        log.info(f"Data Frame : 'Top_Selling_Product_df' is built....")
 
         JNR_Supplier_Aggregates_And_Top_Product = SQ_Shortcut_To_Suppliers.join(
             AGG_TRANS_Supplier_Level, on="SUPPLIER_ID", how="left"
@@ -102,6 +118,7 @@ def m_load_supplier_performance():
                 "No Sales"
             ).otherwise(col("TOP_SELLING_PRODUCT"))
         ).withColumn("DAY_DT", current_date())
+        log.info(f"Data Frame : 'JNR_Supplier_Aggregates_And_Top_Product' is built....")
 
         Shortcut_To_Supplier_Performance_Tgt = JNR_Supplier_Aggregates_And_Top_Product.select(
                                                 col("DAY_DT"),
@@ -112,7 +129,7 @@ def m_load_supplier_performance():
                                                 col("agg_total_stock_sold").alias("TOTAL_STOCK_SOLD"),
                                                 col("TOP_SELLING_PRODUCT")
                                               )
-
+        log.info(f"Data Frame : 'Shortcut_To_Supplier_Performance_Tgt' is built....")
         
         validator = DuplicateValidator()
         validator.validate_no_duplicates(Shortcut_To_Supplier_Performance_Tgt,key_columns=["SUPPLIER_ID", "DAY_DT"] )
@@ -127,4 +144,7 @@ def m_load_supplier_performance():
         raise AirflowException(f"Supplier_performance ETL failed: {str(e)}")
 
     finally:
-        spark.stop()
+        spark.stop()     
+                                                                                                          
+                              
+        

--- a/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
@@ -1,8 +1,8 @@
 from airflow.decorators import task
 from airflow.exceptions import AirflowException
-from utils import init_spark,load_to_postgres,DuplicateValidator, read_from_postgres
+from utils import init_spark, load_to_postgres, DuplicateValidator, read_from_postgres
 import logging
-from pyspark.sql.functions import col, sum , countDistinct, current_date, row_number,when
+from pyspark.sql.functions import col, sum , countDistinct, current_date, row_number, when
 from pyspark.sql.window import Window
 
 log = logging.getLogger(__name__)

--- a/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
@@ -1,0 +1,120 @@
+from airflow.decorators import task
+from airflow.exceptions import AirflowException
+from utils import init_spark,load_to_postgres,DuplicateValidator,read_from_postgres
+import logging
+from pyspark.sql.functions import col, sum , countDistinct, current_date, row_number,when
+from pyspark.sql.window import Window
+
+log = logging.getLogger(__name__)
+
+
+@task
+def m_load_supplier_performance():
+    try:
+        spark = init_spark()
+
+        #processing node SQ_Shortcut_To_sales -reads data from sales table
+        SQ_Shortcut_To_sales = read_from_postgres(spark, "raw.sales")
+        SQ_Shortcut_To_sales = SQ_Shortcut_To_sales\
+                                 .select(
+                                    col("ORDER_STATUS"),
+                                    col("PRODUCT_ID"),
+                                    col("QUANTITY"),
+                                    col("SELLING_PRICE")
+                                )        
+        log.info(f"Data Frame : 'SQ_Shortcut_To_sales' is built....")
+
+        SQ_Shortcut_To_products = read_from_postgres(spark, "raw.products")
+        SQ_Shortcut_To_products = SQ_Shortcut_To_products \
+                                     .select(                                      
+                                      col("PRODUCT_ID"),
+                                      col("SUPPLIER_ID"),
+                                      col("PRODUCT_NAME")                                    
+                                    )
+        log.info(f"Data Frame : 'SQ_Shortcut_To_products' is built....")
+
+        SQ_Shortcut_To_suppliers = read_from_postgres(spark, "raw.suppliers")
+        SQ_Shortcut_To_suppliers =  SQ_Shortcut_To_suppliers\
+                                    .select(
+                                        col("SUPPLIER_ID"),
+                                        col("SUPPLIER_NAME")
+                                    )
+        log.info(f"Data Frame : 'SQ_Shortcut_To_suppliers' is built....")
+       
+        FIL_Cancelled_Sales = SQ_Shortcut_To_sales.filter(col("ORDER_STATUS") != "CANCELLED")
+
+        
+        JNR_Sales_Products = FIL_Cancelled_Sales.join(
+            SQ_Shortcut_To_products, on="PRODUCT_ID", how="inner"
+        )
+        JNR_Products_Suppliers = JNR_Sales_Products.join(
+            SQ_Shortcut_To_suppliers, on="SUPPLIER_ID", how="inner"
+        )
+      
+       
+        JNR_Products_Suppliers = JNR_Products_Suppliers.withColumn(
+            "REVENUE", col("QUANTITY") * col("SELLING_PRICE")
+        )
+
+        
+        AGG_TRANS_Product_Level = JNR_Products_Suppliers.groupBy(
+            "SUPPLIER_ID", "PRODUCT_ID", "PRODUCT_NAME"
+        ).agg(
+            sum("REVENUE").alias("agg_product_revenue"),
+            sum("QUANTITY").alias("agg_stock_sold")
+        )
+        
+       
+        AGG_TRANS_Supplier_Level = AGG_TRANS_Product_Level.groupBy("SUPPLIER_ID").agg(
+            sum("agg_product_revenue").alias("agg_total_revenue"),
+            countDistinct("PRODUCT_ID").alias("agg_total_products_sold"),
+            sum("agg_stock_sold").alias("agg_total_stock_sold")
+        )
+
+       
+        windowSpec = Window.partitionBy("SUPPLIER_ID").orderBy(col("agg_product_revenue").desc())
+        ranked_df = AGG_TRANS_Product_Level.withColumn("RANK", row_number().over(windowSpec))
+
+        top_selling_product_df = ranked_df.filter(col("RANK") == 1).select(
+            "SUPPLIER_ID", col("PRODUCT_NAME").alias("TOP_SELLING_PRODUCT")
+        )
+
+        final_result = SQ_Shortcut_To_suppliers.join(
+            AGG_TRANS_Supplier_Level, on="SUPPLIER_ID", how="left"
+        ).join(
+            top_selling_product_df, on="SUPPLIER_ID", how="left"
+        ).fillna(0, subset=[
+            "agg_total_revenue", "agg_total_products_sold", "agg_total_stock_sold"
+        ]).withColumn(
+            "TOP_SELLING_PRODUCT",
+            when(
+                col("TOP_SELLING_PRODUCT").isNull() | (col("TOP_SELLING_PRODUCT") == ""),
+                "No Sales"
+            ).otherwise(col("TOP_SELLING_PRODUCT"))
+        ).withColumn("DAY_DT", current_date())
+
+        Shortcut_To_supplier_performance_tgt = final_result.select(
+                                                col("DAY_DT"),
+                                                col("SUPPLIER_ID"),
+                                                col("SUPPLIER_NAME"),
+                                                col("agg_total_revenue").alias("TOTAL_REVENUE"),
+                                                col("agg_total_products_sold").alias("TOTAL_PRODUCTS_SOLD"),
+                                                col("agg_total_stock_sold").alias("TOTAL_STOCK_SOLD"),
+                                                col("TOP_SELLING_PRODUCT")
+                                              )
+
+        
+        validator = DuplicateValidator()
+        validator.validate_no_duplicates(Shortcut_To_supplier_performance_tgt,key_columns=["SUPPLIER_ID", "DAY_DT"] )
+
+      
+        load_to_postgres(Shortcut_To_supplier_performance_tgt,"legacy.supplier_performance","append")   
+
+        return "Supplier Performance task finished."
+
+    except Exception as e:
+        log.error(f"ETL task failed: {str(e)}", exc_info=True)
+        raise AirflowException(f"Supplier_performance ETL failed: {str(e)}")
+
+    finally:
+        spark.stop()

--- a/ETL_Airflow/dags/utils.py
+++ b/ETL_Airflow/dags/utils.py
@@ -103,18 +103,37 @@ class DuplicateValidator:
         logging.info("No duplicates found. Validation passed.")
 
 # Load DataFrame into PostgreSQL
-def load_to_postgres(df, table_name):
+def load_to_postgres(df, table_name,mode):
     jdbc_url = "jdbc:postgresql://host.docker.internal:5432/meta_morph"
     properties = {
         "user": "postgres",
         "password": POSTGRES_PASSWORD,
         "driver": "org.postgresql.Driver"
     }
+    
+    log.info("Connecting to jdbc for loading to postgres table") 
     df.write.jdbc(
         url=jdbc_url,
         table=table_name,
-        mode="overwrite", 
+        mode=mode, 
         properties=properties
     )
-    log.info("Connecting to jbbc for loading to postgress table") 
     log.info("Loaded data into PostgreSQL successfully")
+
+
+def read_from_postgres(spark, table_name):
+    jdbc_url = "jdbc:postgresql://host.docker.internal:5432/meta_morph"
+    properties = {
+        "user": "postgres",
+        "password": POSTGRES_PASSWORD,
+        "driver": "org.postgresql.Driver"
+    }
+
+    log.info(f"Reading table '{table_name}' from PostgreSQL...")
+    df = spark.read.jdbc(
+        url=jdbc_url,
+        table=table_name,
+        properties=properties
+    )
+    log.info(f"Successfully read '{table_name}' from PostgreSQL.")
+    return df

--- a/ETL_Airflow/dags/utils.py
+++ b/ETL_Airflow/dags/utils.py
@@ -103,7 +103,7 @@ class DuplicateValidator:
         logging.info("No duplicates found. Validation passed.")
 
 # Load DataFrame into PostgreSQL
-def load_to_postgres(df, table_name,mode):
+def load_to_postgres(df, table_name, mode):
     jdbc_url = "jdbc:postgresql://host.docker.internal:5432/meta_morph"
     properties = {
         "user": "postgres",


### PR DESCRIPTION
As part of the [Story](https://trello.com/c/kjM3DCzP/43-sahithi-create-daily-supplierperformance-table-in-legacy-schema-with-sales-insights) : 

- Create Supplier_Performance table in the legacy schema.
- Write data daily in append mode using an automated job.
- Calculate Total_Revenue per supplier accurately.
- Identify and populate the Top_Selling_Product for each supplier.
- Validate data consistency and aggregation logic.
- Add basic logging and error handling.
- Peer review and QA testing.
