### PR TITLE
fix the mismatches in supplier_performance

### DIFF
--- a/ETL_Airflow/dags/adhoc_job.py
+++ b/ETL_Airflow/dags/adhoc_job.py
@@ -1,6 +1,6 @@
 from airflow.decorators import dag
 from datetime import  timedelta
-from tasks.adhoc.adhoc_column_mismatch_20250711_file import  m_adhoc_into_customers,m_adhoc_into_products
+from tasks.adhoc.adhoc_mismatch_supplier_perforamce   import  m_load_supplier_performance
 import pendulum
 
 IST = pendulum.timezone("Asia/Kolkata")
@@ -15,8 +15,9 @@ IST = pendulum.timezone("Asia/Kolkata")
 
 
 def etl_process():
+
+    m_load_supplier_performance()
    
-   m_adhoc_into_customers()
-   m_adhoc_into_products()
+
 
 dag_instance = etl_process()

--- a/ETL_Airflow/dags/metamorph_etl_dag.py
+++ b/ETL_Airflow/dags/metamorph_etl_dag.py
@@ -17,7 +17,6 @@ default_args = {
 @dag(
     dag_id="ingestion_data_pipeline",
     default_args= default_args,
-    start_date=datetime(2025, 7, 6, tzinfo=IST),
     catchup=False,
     tags=["METAMORPH"]
 )
@@ -34,7 +33,7 @@ def etl_process():
    
 
     # Set dependencies inside the DAG function
-    [supplier_task, product_task, customer_task, sales_task]  >> supplier_performance_task >>  product_performance_task >> customer_sales_report_task
+    [supplier_task, product_task, customer_task] >> sales_task  >> supplier_performance_task >>  product_performance_task >> customer_sales_report_task
   
 
 dag_instance = etl_process()

--- a/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
+++ b/ETL_Airflow/dags/tasks/m_supplier_performance_task.py
@@ -16,7 +16,7 @@ def m_load_supplier_performance():
         spark = init_spark()
 
         # Processing Node : SQ_Shortcut_To_sales - Reads data from 'raw.sales_pre' table
-        SQ_Shortcut_To_sales = read_from_postgres(spark, "raw.sales_pre").alias("sales")
+        SQ_Shortcut_To_sales = read_from_postgres(spark, "raw.sales_pre")
         SQ_Shortcut_To_sales = SQ_Shortcut_To_sales\
                                 .select(
                                     col("ORDER_STATUS"),
@@ -28,7 +28,7 @@ def m_load_supplier_performance():
         log.info(f"Data Frame : 'SQ_Shortcut_To_sales' is built....")
 
         # Processing Node : SQ_Shortcut_To_Products - Reads data from 'raw.products_pre' table
-        SQ_Shortcut_To_Products = read_from_postgres(spark, "raw.products_pre").alias("products")
+        SQ_Shortcut_To_Products = read_from_postgres(spark, "raw.products_pre")
         SQ_Shortcut_To_Products = SQ_Shortcut_To_Products \
                                     .select(                                      
                                         col("PRODUCT_ID"),
@@ -39,7 +39,7 @@ def m_load_supplier_performance():
         log.info(f"Data Frame : 'SQ_Shortcut_To_products' is built....")
    
         # Processing Node : SQ_Shortcut_To_Suppliers - Reads data from 'raw.suppliers_pre' table
-        SQ_Shortcut_To_Suppliers = read_from_postgres(spark, "raw.suppliers_pre").alias("suppliers")
+        SQ_Shortcut_To_Suppliers = read_from_postgres(spark, "raw.suppliers_pre")
         SQ_Shortcut_To_Suppliers =  SQ_Shortcut_To_Suppliers\
                                     .select(
                                         col("SUPPLIER_ID"),


### PR DESCRIPTION
As per the [fix/MM-137 ](https://trello.com/c/RLBGwMtD/137-sahithi-data-mismatch-supplierperformance) :

-  Fixed this total revenue , total_stock_sold, total_product_sold  by using trim method on supplier id.
- Fixed the cancelled filter to lower_case .
- Fixed the total_products_sold logic by counting sale id in calculation.

 The Success Screenshot : 
<img width="896" height="573" alt="image" src="https://github.com/user-attachments/assets/a1b93cab-3512-4d93-a6b1-d51929964ec2" />
 
<img width="1526" height="802" alt="image" src="https://github.com/user-attachments/assets/2371d5af-0a68-4cde-8d08-68ebe8f321a5" />


